### PR TITLE
refactor(metrics): use object destructuring for otel prefix

### DIFF
--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -6,7 +6,7 @@ import env from './env';
 
 initializeMetrics({ name: packageInfo.name, version: packageInfo.version });
 
-const prefix = env.otel.prefix;
+const {prefix} = env.otel;
 const meter = packageInfo.name;
 
 export const recordMetric = (metric: AppEvent) => {


### PR DESCRIPTION
This PR addresses a code style issue in the `metrics.ts` file. Previously, we were accessing the `prefix` property from the `otel` object directly. However, using object destructuring can make the code cleaner and easier to understand.

To improve readability, we've updated the code to use object destructuring when accessing the `prefix` property from the `otel` object.

Changes include:
- Updating the `metrics.ts` file to use object destructuring for the `otel` object.

This change should make the code in `metrics.ts` easier to read and maintain.