### PR TITLE
style(stripe): use block braces for conditional statements

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -18,7 +18,9 @@ export async function getStripeCustomerId(teamMember, session?: any) {
         teamId: teamMember.teamId,
       },
     };
-    if (session?.user?.email) customerData.email = session?.user?.email;
+    if (session?.user?.email) {
+      customerData.email = session?.user?.email;
+    }
     const customer = await stripe.customers.create({
       ...customerData,
       name: session?.user?.name as string,

--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -34,7 +34,7 @@ export default async function POST(req: NextApiRequest, res: NextApiResponse) {
   const rawBody = await getRawBody(req);
 
   const sig = req.headers['stripe-signature'] as string;
-  const webhookSecret = env.stripe.webhookSecret;
+  const { webhookSecret } = env.stripe;
   let event: Stripe.Event;
 
   try {


### PR DESCRIPTION
This PR addresses a code style issue in the `stripe.ts` file. Previously, we were using single-line conditional statements without block braces. However, this can potentially lead to confusion and errors in more complex code.

To improve readability and maintainability, we've updated the conditional statements to use block braces. This makes it clear where the conditional code starts and ends, and ensures that we follow best practices for code style.

Changes include:
- Updating the `session.user.email` check in `stripe.ts` to use block braces for the conditional statement.

This change should make the code in `stripe.ts` easier to read and maintain.