### PR TITLE
refactor(dsync): use object destructuring for request body

### DIFF
--- a/pages/api/teams/[slug]/dsync/index.ts
+++ b/pages/api/teams/[slug]/dsync/index.ts
@@ -60,7 +60,7 @@ const handlePOST = async (req: NextApiRequest, res: NextApiResponse) => {
 
   throwIfNotAllowed(teamMember, 'team_dsync', 'create');
 
-  const body = req.body;
+  const {body} = req;
 
   const connection = await dsync.createConnection({
     ...body,

--- a/pages/api/teams/[slug]/dsync/index.ts
+++ b/pages/api/teams/[slug]/dsync/index.ts
@@ -60,7 +60,7 @@ const handlePOST = async (req: NextApiRequest, res: NextApiResponse) => {
 
   throwIfNotAllowed(teamMember, 'team_dsync', 'create');
 
-  const {body} = req;
+  const { body } = req;
 
   const connection = await dsync.createConnection({
     ...body,


### PR DESCRIPTION
This PR addresses a code style issue in the `index.ts` file. Previously, we were accessing the `body` property from the `req` object directly. However, using object destructuring can make the code cleaner and easier to understand.

To improve readability, we've updated the code to use object destructuring when accessing the `body` property from the `req` object.

Changes include:
- Updating the `index.ts` file to use object destructuring for the `req` object.

This change should make the code in `index.ts` easier to read and maintain.