### PR TITLE
refactor(team): merge nested if conditions in updateTeam function

### DIFF
--- a/pages/api/teams/[slug]/index.ts
+++ b/pages/api/teams/[slug]/index.ts
@@ -75,20 +75,22 @@ const handlePUT = async (req: NextApiRequest, res: NextApiResponse) => {
       domain,
     });
   } catch (error: any) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === 'P2002' && error.meta?.target) {
-        const target = error.meta.target as string[];
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002' &&
+      error.meta?.target
+    ) {
+      const target = error.meta.target as string[];
 
-        if (target.includes('slug')) {
-          throw new ApiError(409, 'This slug is already taken for a team.');
-        }
+      if (target.includes('slug')) {
+        throw new ApiError(409, 'This slug is already taken for a team.');
+      }
 
-        if (target.includes('domain')) {
-          throw new ApiError(
-            409,
-            'This domain is already associated with a team.'
-          );
-        }
+      if (target.includes('domain')) {
+        throw new ApiError(
+          409,
+          'This domain is already associated with a team.'
+        );
       }
     }
 


### PR DESCRIPTION
This PR addresses a code style issue in the `updateTeam` function within the `index.ts` file. Previously, we were using nested if conditions to check the error type and error code. However, this can be simplified by merging the nested if conditions into a single condition.

To improve readability, we've updated the `updateTeam` function to merge the nested if conditions.

Changes include:
- Merging the nested if conditions in the `updateTeam` function within `index.ts`.

This change should make the code in `index.ts` easier to read and maintain.