### PR TITLE
refactor(stripe): use object destructuring for webhookSecret

### DIFF
--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -34,7 +34,7 @@ export default async function POST(req: NextApiRequest, res: NextApiResponse) {
   const rawBody = await getRawBody(req);
 
   const sig = req.headers['stripe-signature'] as string;
-  const webhookSecret = env.stripe.webhookSecret;
+  const {webhookSecret} = env.stripe;
   let event: Stripe.Event;
 
   try {


### PR DESCRIPTION
This PR addresses a code style issue in the `stripe.ts` file. Previously, we were accessing the `webhookSecret` property from the `env.stripe` object directly. However, using object destructuring can make the code cleaner and easier to understand.

To improve readability, we've updated the code to use object destructuring when accessing the `webhookSecret` property from the `env.stripe` object.

Changes include:
- Updating the `stripe.ts` file to use object destructuring for the `env.stripe` object.

This change should make the code in `stripe.ts` easier to read and maintain.