### PR TITLE
style(stripe): use block braces for if statement in POST function

### DIFF
--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -34,7 +34,7 @@ export default async function POST(req: NextApiRequest, res: NextApiResponse) {
   const rawBody = await getRawBody(req);
 
   const sig = req.headers['stripe-signature'] as string;
-  const webhookSecret = env.stripe.webhookSecret;
+  const {webhookSecret} = env.stripe;
   let event: Stripe.Event;
 
   try {

--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -34,11 +34,13 @@ export default async function POST(req: NextApiRequest, res: NextApiResponse) {
   const rawBody = await getRawBody(req);
 
   const sig = req.headers['stripe-signature'] as string;
-  const {webhookSecret} = env.stripe;
+  const webhookSecret = env.stripe.webhookSecret;
   let event: Stripe.Event;
 
   try {
-    if (!sig || !webhookSecret) return;
+    if (!sig || !webhookSecret) {
+      return;
+    }
     event = stripe.webhooks.constructEvent(rawBody, sig, webhookSecret);
   } catch (err: any) {
     return res.status(400).json({ error: { message: err.message } });


### PR DESCRIPTION
This PR addresses a code style issue in the `POST` function within the `stripe.ts` file. Previously, we were using a single-line if statement without block braces. However, this can potentially lead to confusion and errors in more complex code.

To improve readability and maintainability, we've updated the if statement to use block braces. This makes it clear where the conditional code starts and ends, and ensures that we follow best practices for code style.

Changes include:
- Updating the `sig` and `webhookSecret` check in `POST` function within `stripe.ts` to use block braces for the if statement.

This change should make the code in `stripe.ts` easier to read and maintain.