### PR TITLE
style(auth): use block braces for if statement in SAMLIdPLogin function

### DIFF
--- a/pages/auth/idp-login.tsx
+++ b/pages/auth/idp-login.tsx
@@ -8,7 +8,9 @@ export default function SAMLIdPLogin() {
   const { isReady, query } = router;
 
   useEffect(() => {
-    if (!isReady) return;
+    if (!isReady) {
+      return;
+    }
 
     signIn('boxyhq-idp', {
       callbackUrl: '/dashboard',


### PR DESCRIPTION
This PR addresses a code style issue in the `SAMLIdPLogin` function within the `idp-login.tsx` file. Previously, we were using a single-line if statement without block braces. However, this can potentially lead to confusion and errors in more complex code.

To improve readability and maintainability, we've updated the if statement to use block braces. This makes it clear where the conditional code starts and ends, and ensures that we follow best practices for code style.

Changes include:
- Updating the `isReady` check in `SAMLIdPLogin` function within `idp-login.tsx` to use block braces for the if statement.

This change should make the code in `idp-login.tsx` easier to read and maintain.