### PR TITLE
feat: 404 and 500 error pages

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -236,5 +236,6 @@
   "invalid-credentials": "Invalid credentials",
   "no-credentials": "No credentials provided",
   "token-not-found": "Verification token not found",
-  "update-webhook": "Update Webhook"
+  "update-webhook": "Update Webhook",
+  "error-404": "Page not found"
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -237,5 +237,13 @@
   "no-credentials": "No credentials provided",
   "token-not-found": "Verification token not found",
   "update-webhook": "Update Webhook",
-  "error-404": "Page not found"
+  "page-not-found": "Page not found",
+  "sorry-not-found": "Sorry, the page you are looking for could not be found.",
+  "error-404": "404",
+  "go-home": "Go Home",
+  "go-back": "Go Back",
+  "error-500": "500",
+  "internal-server-error": "Internal Server Error !",
+  "unable-to-find": "We're unable to find out what's happening! We suggest you to",
+  "try-again-later": "or visit here later."
 }

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,25 @@
+// pages/404.tsx
+import React, { ReactElement } from 'react';
+import { AccountLayout } from '@/components/layouts';
+import { useTranslation } from 'react-i18next'; // Import useTranslation from react-i18next
+import { GetServerSidePropsContext } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+
+function Custom404() {
+  const { t } = useTranslation('common');
+  return <h1>{t('error-404')}</h1>;
+}
+
+Custom404.getLayout = function getLayout(page: ReactElement) {
+  return <AccountLayout>{page}</AccountLayout>;
+};
+
+export default Custom404;
+
+export async function getStaticProps({ locale }: GetServerSidePropsContext) {
+  return {
+    props: {
+      ...(locale ? await serverSideTranslations(locale, ['common']) : {}),
+    },
+  };
+}

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -3,29 +3,22 @@ import { AccountLayout } from '@/components/layouts';
 import { useTranslation } from 'react-i18next';
 import { GetServerSidePropsContext } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import Link from 'next/link';
 import router from 'next/router';
 
-const Custom404 = () => {
+const Custom500 = () => {
   const { t } = useTranslation('common');
   return (
     <div className="w-full items-center justify-center lg:px-2 xl:px-0 text-center dark:bg-black">
       <p className="text-7xl md:text-8xl lg:text-9xl font-bold tracking-wider dark:text-gray-300">
-        {t('error-404')}
+        {t('error-500')}
       </p>
       <p className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-wider dark:text-gray-300 mt-2">
-        {t('page-not-found')}
+        {t('internal-server-error')}
       </p>
       <p className="text-lg md:text-xl lg:text-2xl dark:text-gray-500 my-12">
-        {t('sorry-not-found')}
+        {t('unable-to-find')}
       </p>
       <div className="mt-8 space-x-5">
-        <Link
-          href="/"
-          className="btn btn-primary btn-md py-3 px-2 sm:px-4 text-white"
-        >
-          {t('go-home')}
-        </Link>
         <button
           onClick={(e) => {
             e.preventDefault();
@@ -35,14 +28,17 @@ const Custom404 = () => {
         >
           {t('go-back')}
         </button>
+        <p className="text-lg md:text-xl lg:text-2xl dark:text-gray-500 my-12">
+          {t('try-again-later')}
+        </p>
       </div>
     </div>
   );
 };
 
-export default Custom404;
+export default Custom500;
 
-Custom404.getLayout = function getLayout(page: ReactElement) {
+Custom500.getLayout = function getLayout(page: ReactElement) {
   return <AccountLayout>{page}</AccountLayout>;
 };
 


### PR DESCRIPTION
In the course of implementing error pages, I have focused on the 400 and 500 error codes, recognizing the importance of addressing these common issues to enhance user experience. The 404 error page was initially mentioned, but the inclusion of the 500 error page was also considered due to its prevalence in web environments. However, the ability to thoroughly test the 500 error page was limited, as it is a production page, and access to Sentry values was not available. This limitation prevented a comprehensive review and adjustment of the 500 error page.