### PR TITLE
feat: Implement restrictions: Admins cannot update or delete team owner

### DIFF
--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -2,7 +2,10 @@ import { Role } from '@prisma/client';
 import { ApiError } from './errors';
 import { getTeamMember } from 'models/team';
 
-export async function validateMembershipOperation(memberId: string, teamMember) {
+export async function validateMembershipOperation(
+  memberId: string,
+  teamMember
+) {
   const updatingMember = await getTeamMember(memberId, teamMember.team.slug);
   // Member and Admin can't update the role of Owner
   if (

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -2,7 +2,7 @@ import { Role } from '@prisma/client';
 import { ApiError } from './errors';
 import { getTeamMember } from 'models/team';
 
-export async function validateUpdateRole(memberId: string, teamMember) {
+export async function validateMembershipOperation(memberId: string, teamMember) {
   const updatingMember = await getTeamMember(memberId, teamMember.team.slug);
   // Member and Admin can't update the role of Owner
   if (

--- a/pages/api/teams/[slug]/members.ts
+++ b/pages/api/teams/[slug]/members.ts
@@ -74,6 +74,8 @@ const handleDELETE = async (req: NextApiRequest, res: NextApiResponse) => {
     req.query as { memberId: string }
   );
 
+  await validateMembershipOperation(memberId, teamMember);
+
   const teamMemberRemoved = await removeTeamMember(teamMember.teamId, memberId);
 
   await sendEvent(teamMember.teamId, 'member.removed', teamMemberRemoved);

--- a/pages/api/teams/[slug]/members.ts
+++ b/pages/api/teams/[slug]/members.ts
@@ -11,7 +11,7 @@ import { throwIfNotAllowed } from 'models/user';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { recordMetric } from '@/lib/metrics';
 import { countTeamMembers, updateTeamMember } from 'models/teamMember';
-import { validateUpdateRole } from '@/lib/rbac';
+import { validateMembershipOperation } from '@/lib/rbac';
 import {
   deleteMemberSchema,
   updateMemberSchema,
@@ -154,7 +154,7 @@ const handlePATCH = async (req: NextApiRequest, res: NextApiResponse) => {
     req.body as { memberId: string; role: Role }
   );
 
-  await validateUpdateRole(memberId, teamMember);
+  await validateMembershipOperation(memberId, teamMember);
 
   const memberUpdated = await updateTeamMember({
     where: {


### PR DESCRIPTION
Initially, the objective was to safeguard against the deletion of owner accounts. However, upon further consideration, it was identified that an administrator could circumvent this restriction by altering the role of the owner to either an admin or a user, thereby retaining the ability to delete the owner. To address this vulnerability, the system has been updated to prevent administrators from modifying the role of the owner, thereby enhancing the security measures in place.

Please check.