### PR TITLE
feat: Add script to delete teams and associated data

### DIFF
--- a/delete-team.js
+++ b/delete-team.js
@@ -1,0 +1,70 @@
+const { PrismaClient } = require('@prisma/client');
+
+const init = async () => {
+  if (process.argv.length < 3) {
+    console.log(
+      `Usage: 
+        node delete-team.js <teamId> [teamId]
+        npm run delete-team -- <teamId> [teamId]`
+    );
+    console.log(
+      `Example: 
+        node delete-team.js 01850e43-d1e0-4b92-abe5-271b159ff99b
+        npm run delete-team -- 01850e43-d1e0-4b92-abe5-271b159ff99b`
+    );
+    process.exit(1);
+  } else {
+    const prisma = new PrismaClient();
+    for (let i = 2; i < process.argv.length; i++) {
+      const teamId = process.argv[i];
+      try {
+        console.log('Checking team:', teamId);
+        const teamExists = await prisma.team.findUnique({
+          where: {
+            id: teamId,
+          },
+        });
+        if (!teamExists) {
+          console.log('Team not found:', teamId);
+          continue;
+        }
+        console.log('Deleting team:', teamId);
+        const team = await prisma.team.delete({
+          where: {
+            id: teamId,
+          },
+        });
+        console.log('Team deleted:', team.name);
+        console.log('Deleting team members');
+        await prisma.user.deleteMany({
+          where: {
+            teamMembers: {
+              none: {},
+            },
+          },
+        });
+        console.log('Team members deleted');
+        if (team?.billingId) {
+          console.log('Deleting team subscriptions');
+          await prisma.subscription.deleteMany({
+            where: {
+              customerId: team?.billingId,
+            },
+          });
+          console.log('Team subscriptions deleted');
+        }
+      } catch (error) {
+        console.log('Error deleting team:', error?.message);
+      }
+    }
+    await prisma.$disconnect();
+  }
+};
+
+init();
+
+// handle uncaught errors
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught Exception:', error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:cov": "jest --coverage --env=jsdom",
     "build-ci": "next build",
     "sync-stripe": "node --env-file .env sync-stripe.js",
-    "check-locale": "node check-locale.js"
+    "check-locale": "node check-locale.js",
+    "delete-team": "node delete-team.js"
   },
   "dependencies": {
     "@boxyhq/metrics": "0.2.6",


### PR DESCRIPTION
The code changes include the addition of a new script `delete-team.js` that allows users to delete teams and their associated data. The script takes in one or more team IDs as command-line arguments and performs the deletion process. It uses the Prisma client to interact with the database and performs various deletion operations, including deleting the team, deleting team members, and deleting team subscriptions if applicable.