### PR TITLE
Fix: Reset Role Dropdown to Default After Invitation

### DIFF
--- a/components/invitation/InviteViaEmail.tsx
+++ b/components/invitation/InviteViaEmail.tsx
@@ -73,6 +73,7 @@ const InviteViaEmail = ({ setVisible, team }: InviteViaEmailProps) => {
           className="select-bordered select rounded"
           name="role"
           onChange={formik.handleChange}
+          value={formik.values.role}
           required
         >
           {availableRoles.map((role) => (

--- a/components/invitation/InviteViaLink.tsx
+++ b/components/invitation/InviteViaLink.tsx
@@ -142,6 +142,7 @@ const InviteViaLink = ({ team }: InviteViaLinkProps) => {
           className="select-bordered select rounded"
           name="role"
           onChange={formik.handleChange}
+          value={formik.values.role}
           required
         >
           {availableRoles.map((role) => (


### PR DESCRIPTION
This PR fixes an issue where the role dropdown retains the role selected for the previous invitee, leading to potential confusion and incorrect role assignments.

Changes Made:
Added a value attribute to the <select> element to control its value through Formik's state, ensuring the dropdown resets to the default 'Member' role after each invitation.

This update aims to improve user experience by ensuring accurate role assignment.