### PR TITLE
feat: Add validation for updating member roles

### DIFF
--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -4,7 +4,10 @@ import { getTeamMember } from 'models/team';
 
 export async function validateMembershipOperation(
   memberId: string,
-  teamMember
+  teamMember,
+  operationMeta?: {
+    role?: Role;
+  }
 ) {
   const updatingMember = await getTeamMember(memberId, teamMember.team.slug);
   // Member and Admin can't update the role of Owner
@@ -25,6 +28,25 @@ export async function validateMembershipOperation(
     throw new ApiError(
       403,
       'You do not have permission to update the role of this member.'
+    );
+  }
+
+  // Admin can't make anyone an Owner
+  if (teamMember.role === Role.ADMIN && operationMeta?.role === Role.OWNER) {
+    throw new ApiError(
+      403,
+      'You do not have permission to update the role of this member to Owner.'
+    );
+  }
+
+  // Member can't make anyone an Admin or Owner
+  if (
+    teamMember.role === Role.MEMBER &&
+    (operationMeta?.role === Role.ADMIN || operationMeta?.role === Role.OWNER)
+  ) {
+    throw new ApiError(
+      403,
+      'You do not have permission to update the role of this member to Admin.'
     );
   }
 }

--- a/pages/api/teams/[slug]/members.ts
+++ b/pages/api/teams/[slug]/members.ts
@@ -155,7 +155,7 @@ const handlePATCH = async (req: NextApiRequest, res: NextApiResponse) => {
     updateMemberSchema,
     req.body as { memberId: string; role: Role }
   );
-  debugger;
+
   await validateMembershipOperation(memberId, teamMember, {
     role,
   });

--- a/pages/api/teams/[slug]/members.ts
+++ b/pages/api/teams/[slug]/members.ts
@@ -155,8 +155,10 @@ const handlePATCH = async (req: NextApiRequest, res: NextApiResponse) => {
     updateMemberSchema,
     req.body as { memberId: string; role: Role }
   );
-
-  await validateMembershipOperation(memberId, teamMember);
+  debugger;
+  await validateMembershipOperation(memberId, teamMember, {
+    role,
+  });
 
   const memberUpdated = await updateTeamMember({
     where: {


### PR DESCRIPTION
This commit adds validation logic to the `validateMembershipOperation` function in the `rbac.ts` file. The validation ensures that an admin cannot make a member an owner and that a member cannot make someone an admin or owner. This prevents unauthorized role changes within the team membership system.