### PR TITLE
feat: Add Svix application deletion functionality

### DIFF
--- a/delete-team.js
+++ b/delete-team.js
@@ -2,6 +2,9 @@ const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
 const jackson = require('@boxyhq/saml-jackson');
 const readline = require('readline');
+const { Svix } = require('svix');
+
+const svix = new Svix(`${process.env.SVIX_API_KEY}`);
 
 const product = process.env.JACKSON_PRODUCT_ID || 'boxyhq';
 
@@ -189,6 +192,21 @@ async function displayDeletionArtifacts(teamId) {
   } else {
     console.log('\nNo invitations found');
   }
+
+  console.log('\nChecking Svix application');
+  const application = await getSvixApplication(team.id);
+  if (!application) {
+    console.log('No Svix application found');
+  } else {
+    printTable([application], ['id', 'name', 'uid']);
+    const webhooks = await svix.endpoint.list(application.id);
+    if (webhooks?.data?.length) {
+      console.log('\nSvix Webhooks:');
+      printTable(webhooks.data, ['id', 'filterTypes', 'url']);
+    } else {
+      console.log('\nNo webhooks found');
+    }
+  }
 }
 
 async function handleTeamDeletion(teamId) {
@@ -216,6 +234,9 @@ async function handleTeamDeletion(teamId) {
     await removeSSOConnections(team);
     await removeTeamSubscriptions(team);
     await removeTeamMembers(team);
+
+    await removeSvixApplication(team.id);
+
     await removeTeam(team);
   }
 }
@@ -446,6 +467,25 @@ async function deleteConnection(directoryId) {
 
     return { data };
   }
+}
+
+async function getSvixApplication(teamId) {
+  try {
+    const application = await svix.application.get(teamId);
+    return application;
+  } catch (ex) {
+    console.log('Error getting application:', ex);
+  }
+}
+
+async function removeSvixApplication(teamId) {
+  console.log('\nDeleting Svix application:', teamId);
+  try {
+    await svix.application.delete(teamId);
+  } catch (ex) {
+    console.log('Error deleting application:', ex);
+  }
+  console.log('Svix application deleted:', teamId);
 }
 
 async function askForConfirmation(teamId) {


### PR DESCRIPTION
The code changes in this commit add functionality to delete Svix applications. The `delete-team.js` file has been modified to include functions for retrieving and removing Svix applications associated with a team. The `displayDeletionArtifacts` function now checks for Svix applications and displays their details if found. The `handleTeamDeletion` function has been updated to call the new `removeSvixApplication` function to delete the Svix application before removing the team. Additionally, two new helper functions, `getSvixApplication` and `removeSvixApplication`, have been added to handle the retrieval and deletion of Svix applications.