### PR TITLE
feat: Add throwIfNoAccessToApiKey guard function

### DIFF
--- a/lib/guards/team-api-key.ts
+++ b/lib/guards/team-api-key.ts
@@ -1,7 +1,10 @@
 import { getApiKeyById } from 'models/apiKey';
 import { ApiError } from '../errors';
 
-export const throwIfNoAccessToApiKey = async (apiKeyId: string, teamId: string) => {
+export const throwIfNoAccessToApiKey = async (
+  apiKeyId: string,
+  teamId: string
+) => {
   const apiKey = await getApiKeyById(apiKeyId);
 
   if (!apiKey) {

--- a/lib/guards/team-api-key.ts
+++ b/lib/guards/team-api-key.ts
@@ -1,0 +1,17 @@
+import { getApiKeyById } from 'models/apiKey';
+import { ApiError } from '../errors';
+
+export const throwIfNoAccessToApiKey = async (apiKeyId: string, teamId: string) => {
+  const apiKey = await getApiKeyById(apiKeyId);
+
+  if (!apiKey) {
+    throw new ApiError(404, 'API key not found');
+  }
+
+  if (teamId !== apiKey.teamId) {
+    throw new ApiError(
+      403,
+      'You do not have permission to delete this API key'
+    );
+  }
+};

--- a/models/apiKey.ts
+++ b/models/apiKey.ts
@@ -64,3 +64,15 @@ export const getApiKey = async (apiKey: string) => {
     },
   });
 };
+
+export const getApiKeyById = async (id: string) => {
+  return prisma.apiKey.findUnique({
+    where: {
+      id,
+    },
+    select: {
+      id: true,
+      teamId: true,
+    },
+  });
+};

--- a/pages/api/teams/[slug]/api-keys/[apiKeyId].ts
+++ b/pages/api/teams/[slug]/api-keys/[apiKeyId].ts
@@ -6,6 +6,7 @@ import { recordMetric } from '@/lib/metrics';
 import env from '@/lib/env';
 import { ApiError } from '@/lib/errors';
 import { deleteApiKeySchema, validateWithSchema } from '@/lib/zod';
+import { throwIfNoAccessToApiKey } from '@/lib/guards/team-api-key';
 
 export default async function handler(
   req: NextApiRequest,
@@ -43,6 +44,8 @@ const handleDELETE = async (req: NextApiRequest, res: NextApiResponse) => {
   throwIfNotAllowed(user, 'team_api_key', 'delete');
 
   const { apiKeyId } = validateWithSchema(deleteApiKeySchema, req.query);
+
+  await throwIfNoAccessToApiKey(apiKeyId, user.team.id);
 
   await deleteApiKey(apiKeyId);
 

--- a/pages/api/teams/[slug]/webhooks/[endpointId].ts
+++ b/pages/api/teams/[slug]/webhooks/[endpointId].ts
@@ -38,8 +38,8 @@ export default async function handler(
         });
     }
   } catch (err: any) {
-    const message = err.message || 'Something went wrong';
-    const status = err.status || 500;
+    const message = err?.body?.detail || err.message || 'Something went wrong';
+    const status = err.status || err.code || 500;
 
     res.status(status).json({ error: { message } });
   }
@@ -98,6 +98,8 @@ const handlePUT = async (req: NextApiRequest, res: NextApiResponse) => {
   if (eventTypes.length > 0) {
     data['filterTypes'] = eventTypes;
   }
+  // Checks if the webhook exists or throws an error
+  await findWebhook(app.id, endpointId);
 
   const webhook = await updateWebhook(app.id, endpointId, data);
 


### PR DESCRIPTION
Adds the `throwIfNoAccessToApiKey` guard function to the `lib/guards/team-api-key.ts` file. This function is responsible for checking if the user has access to the specified API key before performing any actions on it. It throws an `ApiError` with the appropriate status code and error message if the user does not have access.

The guard function is used in the `pages/api/teams/[slug]/api-keys/[apiKeyId].ts` file to ensure that the user has permission to delete the API key before proceeding with the deletion.