### PR TITLE
chore: Remove redundant Sentry configurations

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,17 +3,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 export function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    Sentry.init({
-      dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-      tracesSampleRate: parseFloat(
-        process.env.NEXT_PUBLIC_SENTRY_TRACE_SAMPLE_RATE ?? '0.0'
-      ),
-      debug: false,
-    });
-  }
-
-  if (process.env.NEXT_RUNTIME === 'edge') {
+  if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init({
       dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
       tracesSampleRate: parseFloat(

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,25 @@
+// instrumentation.ts
+
+import * as Sentry from '@sentry/nextjs';
+
+export function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    Sentry.init({
+      dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+      tracesSampleRate: parseFloat(
+        process.env.NEXT_PUBLIC_SENTRY_TRACE_SAMPLE_RATE ?? '0.0'
+      ),
+      debug: false,
+    });
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    Sentry.init({
+      dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+      tracesSampleRate: parseFloat(
+        process.env.NEXT_PUBLIC_SENTRY_TRACE_SAMPLE_RATE ?? '0.0'
+      ),
+      debug: false,
+    });
+  }
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,7 +3,10 @@
 import * as Sentry from '@sentry/nextjs';
 
 export function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' ||
+    process.env.NEXT_RUNTIME === 'edge'
+  ) {
     Sentry.init({
       dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
       tracesSampleRate: parseFloat(

--- a/next.config.js
+++ b/next.config.js
@@ -31,9 +31,6 @@ const nextConfig = {
       },
     ];
   },
-  sentry: {
-    hideSourceMaps: true,
-  },
   async headers() {
     return [
       {
@@ -61,6 +58,7 @@ const nextConfig = {
 // For all available options: https://github.com/getsentry/sentry-webpack-plugin#options.
 const sentryWebpackPluginOptions = {
   silent: true,
+  hideSourceMaps: true,
 };
 
 module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,9 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: parseFloat(
-    process.env.NEXT_PUBLIC_SENTRY_TRACE_SAMPLE_RATE ?? '0.0'
-  ),
-  debug: false,
-});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,9 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: parseFloat(
-    process.env.NEXT_PUBLIC_SENTRY_TRACE_SAMPLE_RATE ?? '0.0'
-  ),
-  debug: false,
-});


### PR DESCRIPTION
Sentry was causing issues for `npm run dev` due to some changes in the configuration.

These changes fixes those.