### PR TITLE
chore: Update docker-compose.yml to remove version field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: postgres


### PR DESCRIPTION
# Fixes docker-compose.yaml: `version` is obsolete
