### PR TITLE
Increase e2e test timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,8 @@ import { PlaywrightTestConfig, devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   workers: 1,
   globalSetup: require.resolve('./tests/e2e/support/globalSetup.ts'),
+  // Timeout per test
+  timeout: 100 * 1000,
   // Assertion timeout
   expect: {
     timeout: 10 * 1000,


### PR DESCRIPTION
Similar to what we have in Jackson, it makes sense to increase the test timeout to avoid timeouts in CI runs.