### PR TITLE
Add documentation on how to protect page with specific Stripe Subscription

### DIFF
--- a/components/shared/AccessControl.tsx
+++ b/components/shared/AccessControl.tsx
@@ -1,5 +1,6 @@
 import type { Action, Resource } from '@/lib/permissions';
 import useCanAccess from 'hooks/useCanAccess';
+import useActiveSubscription from 'hooks/useActiveSubscription';
 
 interface AccessControlProps {
   children: React.ReactNode;
@@ -13,8 +14,9 @@ export const AccessControl = ({
   actions,
 }: AccessControlProps) => {
   const { canAccess } = useCanAccess();
+  const { hasActiveSubscription } = useActiveSubscription();
 
-  if (!canAccess(resource, actions)) {
+  if (!canAccess(resource, actions) || !hasActiveSubscription()) {
     return null;
   }
 


### PR DESCRIPTION
Related to #1041

Add documentation and code changes to protect a page with a specific Stripe Subscription.

* **README.md**:
  - Add a new section explaining how to protect a page with a specific Stripe Subscription.
  - Include code examples for checking active Stripe Subscription in `middleware.ts` and `AccessControl.tsx`.

* **components/shared/AccessControl.tsx**:
  - Import `useActiveSubscription` hook.
  - Add a check for active Stripe Subscription in the `useCanAccess` hook.
  - Update the `AccessControl` component to include the new check.

* **middleware.ts**:
  - Import `getByCustomerId` from `models/subscription`.
  - Add a check for active Stripe Subscription before allowing access to protected routes.
  - Update the `redirectUrl` logic to handle subscription-based access control.

