### PR TITLE
Fixes  #1285 : API Errors are not localized

### DIFF
--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -49,7 +49,7 @@ const ForgotPassword: NextPageWithLayout<
       recaptchaRef.current?.reset();
 
       if (!response.ok) {
-        toast.error(json.error.message);
+        toast.error(t(`${json.error.message}`));
         return;
       }
 


### PR DESCRIPTION
### 🔥 **Issue Reference**
Fixes #1285

### ✨ **What I Did**
- Localized API error messages in `pages/auth/forgot-password.tsx`.
- Used the `t()` function for consistent localization.

Before:
- Error messages displayed only in English.

After:
- Error messages are now localized.
