### PR TITLE
feat: add S3 file upload support via pushduck

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,10 @@ STRIPE_WEBHOOK_SECRET=
 
 # Support URL
 NEXT_PUBLIC_SUPPORT_URL=
+
+# File Uploads (pushduck - https://github.com/abhay-ramesh/pushduck)
+AWS_S3_ACCESS_KEY_ID=
+AWS_S3_SECRET_ACCESS_KEY=
+AWS_S3_REGION=us-east-1
+AWS_S3_BUCKET_NAME=
+# Cloudflare R2 alternative: replace provider with "cloudflareR2" and add CLOUDFLARE_ACCOUNT_ID

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -1,0 +1,186 @@
+import React, { useRef } from 'react';
+import { createUploadClient } from 'pushduck/client';
+import type { AppUploadRouter } from '../pages/api/upload/index';
+
+const upload = createUploadClient<AppUploadRouter>({
+  endpoint: '/api/upload',
+});
+
+export function ImageUpload() {
+  const { uploadFiles, files, isUploading, reset } = upload.imageUpload();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files ?? []);
+    if (selected.length > 0) uploadFiles(selected);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="border-2 border-dashed border-base-300 rounded-lg p-8 text-center cursor-pointer hover:border-primary transition-colors"
+        onClick={() => inputRef.current?.click()}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={handleChange}
+          disabled={isUploading}
+        />
+        {isUploading ? (
+          <p className="text-base-content/60">Uploading...</p>
+        ) : (
+          <p className="text-base-content/60">
+            Click to select images (JPEG, PNG, GIF, WebP &mdash; max 4MB each)
+          </p>
+        )}
+      </div>
+
+      {files.length > 0 && (
+        <div className="space-y-2">
+          {files.map((file) => (
+            <div
+              key={file.id}
+              className="flex items-center gap-3 p-3 bg-base-200 rounded-lg"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{file.name}</p>
+                {file.status === 'uploading' && (
+                  <div className="w-full bg-base-300 rounded-full h-1.5 mt-1">
+                    <div
+                      className="bg-primary h-1.5 rounded-full transition-all"
+                      style={{ width: `${file.progress}%` }}
+                    />
+                  </div>
+                )}
+                {file.status === 'success' && file.url && (
+                  <a
+                    href={file.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-primary hover:underline break-all"
+                  >
+                    {file.url}
+                  </a>
+                )}
+                {file.status === 'error' && (
+                  <p className="text-xs text-error">
+                    {file.error ?? 'Upload failed'}
+                  </p>
+                )}
+              </div>
+              <span
+                className={`badge badge-sm ${
+                  file.status === 'success'
+                    ? 'badge-success'
+                    : file.status === 'error'
+                      ? 'badge-error'
+                      : 'badge-ghost'
+                }`}
+              >
+                {file.status === 'uploading'
+                  ? `${file.progress}%`
+                  : file.status}
+              </span>
+            </div>
+          ))}
+          <button className="btn btn-sm btn-ghost" onClick={reset}>
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DocumentUpload() {
+  const { uploadFiles, files, isUploading, reset } = upload.documentUpload();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files ?? []);
+    if (selected.length > 0) uploadFiles(selected);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="border-2 border-dashed border-base-300 rounded-lg p-8 text-center cursor-pointer hover:border-primary transition-colors"
+        onClick={() => inputRef.current?.click()}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleChange}
+          disabled={isUploading}
+        />
+        {isUploading ? (
+          <p className="text-base-content/60">Uploading...</p>
+        ) : (
+          <p className="text-base-content/60">
+            Click to select files (any type &mdash; max 16MB each)
+          </p>
+        )}
+      </div>
+
+      {files.length > 0 && (
+        <div className="space-y-2">
+          {files.map((file) => (
+            <div
+              key={file.id}
+              className="flex items-center gap-3 p-3 bg-base-200 rounded-lg"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{file.name}</p>
+                {file.status === 'uploading' && (
+                  <div className="w-full bg-base-300 rounded-full h-1.5 mt-1">
+                    <div
+                      className="bg-primary h-1.5 rounded-full transition-all"
+                      style={{ width: `${file.progress}%` }}
+                    />
+                  </div>
+                )}
+                {file.status === 'success' && file.url && (
+                  <a
+                    href={file.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-primary hover:underline"
+                  >
+                    {file.url}
+                  </a>
+                )}
+                {file.status === 'error' && (
+                  <p className="text-xs text-error">
+                    {file.error ?? 'Upload failed'}
+                  </p>
+                )}
+              </div>
+              <span
+                className={`badge badge-sm ${
+                  file.status === 'success'
+                    ? 'badge-success'
+                    : file.status === 'error'
+                      ? 'badge-error'
+                      : 'badge-ghost'
+                }`}
+              >
+                {file.status === 'uploading'
+                  ? `${file.progress}%`
+                  : file.status}
+              </span>
+            </div>
+          ))}
+          <button className="btn btn-sm btn-ghost" onClick={reset}>
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "micromatch": "4.0.8",
     "mixpanel-browser": "2.76.0",
     "next": "15.5.14",
+    "pushduck": "^0.4.0",
     "next-auth": "4.24.13",
     "next-i18next": "15.4.3",
     "nodemailer": "7.0.11",

--- a/pages/api/upload/index.ts
+++ b/pages/api/upload/index.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth';
+import { createUploadConfig } from 'pushduck/server';
+import { toNextJsPagesHandler } from 'pushduck/adapters/nextjs-pages';
+import { getAuthOptions } from '@/lib/nextAuth';
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+};
+
+const { s3 } = createUploadConfig()
+  .provider('aws', {
+    accessKeyId: process.env.AWS_S3_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_S3_SECRET_ACCESS_KEY!,
+    region: process.env.AWS_S3_REGION!,
+    bucket: process.env.AWS_S3_BUCKET_NAME!,
+  })
+  .paths({
+    prefix: 'uploads',
+    generateKey: (file, metadata) => {
+      const userId = (metadata as { userId?: string }).userId ?? 'anonymous';
+      const timestamp = Date.now();
+      return `${userId}/${timestamp}/${file.name}`;
+    },
+  })
+  .build();
+
+const uploadRouter = s3.createRouter({
+  imageUpload: s3
+    .image()
+    .maxFileSize('4MB')
+    .formats(['jpeg', 'jpg', 'png', 'gif', 'webp'])
+    .middleware(async ({ req }) => {
+      const apiReq = req as NextApiRequest;
+      const fakeRes = {} as NextApiResponse;
+      const authOptions = getAuthOptions(apiReq, fakeRes);
+      const session = await getServerSession(apiReq, fakeRes, authOptions);
+      if (!session?.user?.id) {
+        throw new Error('Unauthorized');
+      }
+      return { userId: session.user.id };
+    }),
+  documentUpload: s3
+    .file()
+    .maxFileSize('16MB')
+    .middleware(async ({ req }) => {
+      const apiReq = req as NextApiRequest;
+      const fakeRes = {} as NextApiResponse;
+      const authOptions = getAuthOptions(apiReq, fakeRes);
+      const session = await getServerSession(apiReq, fakeRes, authOptions);
+      if (!session?.user?.id) {
+        throw new Error('Unauthorized');
+      }
+      return { userId: session.user.id };
+    }),
+});
+
+export type AppUploadRouter = typeof uploadRouter;
+
+export default toNextJsPagesHandler(uploadRouter.handlers);


### PR DESCRIPTION
## What

Adds authenticated file upload capability (images and documents) to the SaaS Starter Kit using [pushduck](https://github.com/abhay-ramesh/pushduck) (v0.4.0).

**Files added/changed:**
- `pages/api/upload/index.ts` — upload API route with `imageUpload` and `documentUpload` handlers
- `components/FileUpload.tsx` — `ImageUpload` and `DocumentUpload` React components (DaisyUI + Tailwind styled)
- `.env.example` — AWS S3 environment variable stubs (Cloudflare R2 compatible)
- `package.json` — adds `pushduck@^0.4.0` dependency

## Why

File upload is one of the most commonly needed features in SaaS applications (profile photos, attachments, documents). The starter kit currently has no file upload mechanism, so every team building on it has to wire this up from scratch.

## How it works

pushduck uses the **presigned URL pattern** — the server generates a short-lived signed S3 URL, and the browser uploads directly to S3. This means:

- **No server bandwidth cost** for file transfers
- **No file data touches your API server** — only metadata
- Files are gated behind a **NextAuth session check** in the middleware, so unauthenticated users cannot upload
- Keys are namespaced by `userId/timestamp/filename` to avoid collisions

## Environment variables required

```env
AWS_S3_ACCESS_KEY_ID=
AWS_S3_SECRET_ACCESS_KEY=
AWS_S3_REGION=us-east-1
AWS_S3_BUCKET_NAME=
```

Cloudflare R2 is also supported — change the provider to `"cloudflareR2"` and add `CLOUDFLARE_ACCOUNT_ID`.

## Usage example

```tsx
import { ImageUpload, DocumentUpload } from '@/components/FileUpload';

// In any page or component:
export default function SettingsPage() {
  return (
    <div>
      <h2>Upload Profile Photo</h2>
      <ImageUpload />

      <h2>Upload Documents</h2>
      <DocumentUpload />
    </div>
  );
}
```

## Test plan

- [ ] Set the four `AWS_S3_*` env vars pointing to a real (or localstack) bucket
- [ ] Sign in as any user
- [ ] Navigate to a page using `<ImageUpload />` — select a JPEG/PNG and confirm it uploads and returns a URL
- [ ] Navigate to a page using `<DocumentUpload />` — select a PDF and confirm upload
- [ ] Confirm that hitting `/api/upload` without a session returns a 401
- [ ] Confirm files appear in the S3 bucket under `uploads/<userId>/<timestamp>/<filename>`

---

> Built with [pushduck](https://github.com/abhay-ramesh/pushduck) — a TypeScript-first S3 upload library for Next.js.