### PR TITLE
Fix #2511: add RBAC authorization checks to payment API endpoints

### DIFF
--- a/pages/api/teams/[slug]/payments/create-checkout-session.ts
+++ b/pages/api/teams/[slug]/payments/create-checkout-session.ts
@@ -4,6 +4,7 @@ import { getSession } from '@/lib/session';
 import { throwIfNoTeamAccess } from 'models/team';
 import { stripe, getStripeCustomerId } from '@/lib/stripe';
 import env from '@/lib/env';
+import { throwIfNotAllowed } from 'models/user';
 import { checkoutSessionSchema, validateWithSchema } from '@/lib/zod';
 
 export default async function handler(
@@ -36,6 +37,7 @@ const handlePOST = async (req: NextApiRequest, res: NextApiResponse) => {
   );
 
   const teamMember = await throwIfNoTeamAccess(req, res);
+  throwIfNotAllowed(teamMember, 'team_payments', 'create');
   const session = await getSession(req, res);
   const customer = await getStripeCustomerId(teamMember, session);
 

--- a/pages/api/teams/[slug]/payments/create-portal-link.ts
+++ b/pages/api/teams/[slug]/payments/create-portal-link.ts
@@ -30,6 +30,8 @@ export default async function handler(
 
 const handlePOST = async (req: NextApiRequest, res: NextApiResponse) => {
   const teamMember = await throwIfNoTeamAccess(req, res);
+  throwIfNotAllowed(teamMember, 'team_payments', 'create');
+  
   const session = await getSession(req, res);
   const customerId = await getStripeCustomerId(teamMember, session);
 

--- a/pages/api/teams/[slug]/payments/products.ts
+++ b/pages/api/teams/[slug]/payments/products.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getStripeCustomerId } from '@/lib/stripe';
 import { getSession } from '@/lib/session';
 import { throwIfNoTeamAccess } from 'models/team';
+import { throwIfNotAllowed } from 'models/user';
 import { getAllServices } from 'models/service';
 import { getAllPrices } from 'models/price';
 import { getByCustomerId } from 'models/subscription';
@@ -33,6 +34,8 @@ export default async function handler(
 const handleGET = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSession(req, res);
   const teamMember = await throwIfNoTeamAccess(req, res);
+  throwIfNotAllowed(teamMember, 'team_payments', 'read');
+  
   if (!session?.user?.id) {
     throw Error('Could not get user');
   }


### PR DESCRIPTION
# Pull Request Title

Fix #2511: add RBAC authorization checks to payment API endpoints

## Related Issue

#2511

## Description

This pull request adds missing RBAC authorization checks to payment-related API endpoints.

Previously, these endpoints verified team membership but did not validate whether the user had permission to access payment functionality. This could allow unauthorized team members to access billing-related actions.

This update ensures payment routes enforce the appropriate `team_payments` permissions.

## Type

* [x] Bug Fix
* [ ] Feature Enhancement
* [ ] Documentation Update
* [ ] Code Refactoring
* [ ] Other (please specify):

## Proposed Changes

* Added RBAC authorization checks to payment API endpoints
* Enforced `team_payments` permissions for billing actions
* Applied existing authorization patterns used elsewhere in the project

## Screenshots / Code Snippets (if applicable)

No screenshots included because this PR modifies backend authorization logic.

## How to Test

1. Access payment endpoints as a user with valid payment permissions.
2. Confirm requests succeed when permissions are allowed.
3. Attempt access with a user lacking payment permissions and confirm access is denied.

## Checklist

* [ ] The code compiles successfully without any errors or warnings
* [ ] The changes have been tested and verified
* [ ] The documentation has been updated (if applicable)
* [x] The changes follow the project's coding guidelines and best practices
* [x] The commit messages are descriptive and follow the project's guidelines
* [x] This pull request has been linked to the related issue (if applicable)

## Additional Information

This PR aligns payment endpoints with the project's existing RBAC security model to ensure consistent authorization behavior across team billing features.
