### PR TITLE
docs(env): clarify DATABASE_URL vs Jackson DB_URL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ SMTP_USER=
 SMTP_PASSWORD=
 SMTP_FROM=
 
+# Application database (read by Prisma). The embedded SAML Jackson reuses this
+# same connection — you do NOT need to set DB_URL from the Jackson docs unless
+# you are running a self-hosted Jackson via JACKSON_URL below.
 # If you are using Docker, you can retrieve the values from: docker-compose.yml
 DATABASE_URL=postgresql://<USER-HERE>:<PASSWORD-HERE>@localhost:5432/<DATABASE NAME HERE>
 


### PR DESCRIPTION
Closes #678.

## Summary

Issue #678 reports that users following [the Jackson env-vars docs](https://boxyhq.com/docs/jackson/deploy/env-variables#db_url) (which use `DB_URL`) get confused because the kit's `.env.example` uses `DATABASE_URL`. From the issue thread, the maintainer (@deepakprabhakara) explained: the embedded Jackson reuses `DATABASE_URL` directly (the kit hands the URL to the embedded Jackson) — `DB_URL` only matters when wiring up a self-hosted or hosted Jackson via `JACKSON_URL`. Both maintainer and reporter agreed this should be documented; this PR does the smallest version of that.

## Change

Three-line comment block in `.env.example` directly above `DATABASE_URL`:

```
# Application database (read by Prisma). The embedded SAML Jackson reuses this
# same connection — you do NOT need to set DB_URL from the Jackson docs unless
# you are running a self-hosted Jackson via JACKSON_URL below.
```

This catches the user at the moment they edit the variable, and points them at the existing `JACKSON_URL` block further down for the self-hosted case.

## Notes

- Comment-only change to `.env.example`. No code or behaviour change.
- Drafted with AI assistance (Claude). Reviewed manually.