### PR TITLE
docs: clarify DATABASE_URL env variable naming vs boxyhq.com docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ SMTP_USER=
 SMTP_PASSWORD=
 SMTP_FROM=
 
+# Database connection string (also referred to as DB_URL in some boxyhq.com docs)
 # If you are using Docker, you can retrieve the values from: docker-compose.yml
 DATABASE_URL=postgresql://<USER-HERE>:<PASSWORD-HERE>@localhost:5432/<DATABASE NAME HERE>
 


### PR DESCRIPTION
## Summary
Fixes #678 — resolves confusion around the database connection env variable name.

## Problem
The `.env.example` uses `DATABASE_URL` (which the code reads) but the boxyhq.com deploy docs reference `DB_URL`. This inconsistency caused confusion for new users setting up the project.

## Change
Added a clarifying comment in `.env.example` noting that `DATABASE_URL` is the variable name used in this repo and is the same as `DB_URL` referenced in some boxyhq.com documentation pages.

## Type of Change
- [x] Documentation